### PR TITLE
Updating docker command on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If nothing is missing, your docker run command when testing locally should look 
     -e USER=$USER \
     -e PASS=$PASS \
     -e HOST=$HOST \
-    -e PORT=$PORT \
+    -e API_PORT=$API_PORT \
     -e PRIV_KEY=$PRIV_KEY \
     -e API_KEY=$API_KEY \
     -i -t ada bash


### PR DESCRIPTION
**Motivation:**
- [Internally](https://github.com/IBM/ada/blob/094e6d47c7b6a4cc1857eb1e792f83f591acc505/app.py#L77)  the Ada Code uses the `API_PORT` environmental variable while the example in `README.md` documentation is using `PORT` instead. With the provided example, the service will not be deployed correctly. 

**Description:** The changes includes:
- Replacing `PORT` with `API_PORT` in the `README.md` documentation.

**Verification process:** The documentation is now displaying the correct docker command.